### PR TITLE
Fonts and css vars

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,21 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web site created using create-react-app"
-    />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
+
+<head>
+  <meta charset="utf-8" />
+  <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="description" content="Web site created using create-react-app" />
+  <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+  <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;600;800&display=swap" rel="stylesheet">
+  <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -24,12 +23,13 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <!--
+  <title>React App</title>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+  <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
 
@@ -39,5 +39,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-  </body>
+</body>
+
 </html>

--- a/src/App.css
+++ b/src/App.css
@@ -1,38 +1,8 @@
-.App {
-  text-align: center;
-}
-
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+:root{
+  --color-main: #1C307A;
+  --color-img: #7CA6EE;
+  --color-accent: #B2CBF5;
+  --color-btn-primary: #568CDB;
+  --color-btn-secondary: #6D97D5;
+  --color-background: #F6F6F6;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1,8 +1,21 @@
 :root{
+  --fontSize-desktop-heading: 64px;
+  --fontSize-desktop-subHeading: 50px;
+  --fontSize-desktop-subSubHeading: 30px;
+  --fontSize-desktop-body: 20px;
+
+  --fontSize-mobile-heading: 30px;
+  --fontSize-mobile-subHeading: 20px;
+  --fontSize-mobile-body: 16px;
+
   --color-main: #1C307A;
   --color-img: #7CA6EE;
   --color-accent: #B2CBF5;
-  --color-btn-primary: #568CDB;
-  --color-btn-secondary: #6D97D5;
+  --color-btnPrimary: #568CDB;
+  --color-btnSecondary: #6D97D5;
   --color-background: #F6F6F6;
+}
+
+#app{
+  font-family: "Barlow";
 }

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import './App.css';
 
 function App() {
   return (
-    <div className="App">
+    <div id="app">
       <header className="App-header">
         <img src={logo} className="App-logo" alt="logo" />
         <p>


### PR DESCRIPTION
Added link to Google fonts for Barlow with correct weights.

Made Barlow the default font by add it to the app's root container CSS.

Added CSS vars that can be used via `var(--css-var-name)` for fonts and colours,

Auto-format converted 4 space indents to 2 space indents in index.js.