### PR TITLE
UpcomingEvent refactor

### DIFF
--- a/src/components/UpcomingEvent.js
+++ b/src/components/UpcomingEvent.js
@@ -2,8 +2,6 @@ import React from "react"
 
 import styles from "../css/UpcomingEvent.module.css"
 
-import backgroundBodySrc from "../assets/event-card-body.svg"
-import backgroundEdgeSrc from "../assets/event-card-edge.svg"
 import mapMarker from "../icons/map-marker.svg"
 import clock from "../icons/time.svg"
 
@@ -11,8 +9,15 @@ export default props => {
   return (
     <div id={styles.container}>
       <div className={styles.background}>
-        <img src={backgroundBodySrc} className={styles.backgroundBody} alt="" />
-        <img src={backgroundEdgeSrc} className={styles.backgroundEdge} alt="" />
+        <svg className={styles.backgroundBody} width="260" height="275" viewBox="0 0 260 275" fill="none" preserveAspectRatio="none">
+          <rect fill={props.fill?.accent || "#2B5699"} width="260" height="7.09677" />
+          <rect fill={props.fill?.body || "#3D73C7"} y="7" width="260" height="268" />
+        </svg>
+        <svg className={styles.backgroundEdge} width="47" height="275" viewBox="0 0 47 275" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path fill={props.fill?.body || "#3D73C7"} d="M0 7H46L46.5 241L0 275V7Z" />
+          <path fill={props.fill?.accent || "#2B5699"} d="M46.4516 241L0 275C1.99307 266.118 2.506 261.361 0 250.355C18.8197 250.943 28.9012 248.339 46.4516 241Z" />
+          <rect fill={props.fill?.accent || "#2B5699"} width="46" height="7" />
+        </svg>
       </div>
       <div className={styles.header}>
         <div className={styles.date}>

--- a/src/css/UpcomingEvent.module.css
+++ b/src/css/UpcomingEvent.module.css
@@ -2,6 +2,8 @@
   width: 82%;
   margin: auto;
   color: #ffffff;
+  height: 275px;
+  margin-bottom: 36px;
 }
 
 .header {
@@ -81,6 +83,7 @@
   width: 75%;
   border: #ffffff solid;
   border-width: 1px;
+  color: white;
   text-decoration: none;
   text-align: center;
   margin: 25px auto 0 auto;


### PR DESCRIPTION
Modify `UpcomingEvent` component:

Moved SVGs inline instead of imports so that direct manipulation of fills can occur.

new prop: `fill: {body: "#abc", accent: "#def"}` used to color the main part and top part/corner respectively. 